### PR TITLE
Fix responsive layout on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
             border-radius: 10px;
             box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
             margin-bottom: 20px;
+            flex-wrap: wrap;
         }
 
         .card {
@@ -99,6 +100,17 @@
             flex-direction: column;
             align-items: center;
             justify-content: center;
+        }
+
+        @media (max-width: 768px) {
+            .container {
+                flex-direction: column;
+                align-items: center;
+            }
+            .text-content,
+            .media-card {
+                width: 100%;
+            }
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- allow cards to wrap inside the index page
- stack cards vertically on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686ca537db7083338c389c8e03e1ca93